### PR TITLE
feat: add StorageWrapper for dual-write PostgreSQL support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -608,6 +608,22 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.1"
+description = "Composable command line interface toolkit"
+optional = true
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "extra == \"postgres\""
+files = [
+    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
+    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -618,7 +634,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
+markers = {main = "extra == \"postgres\" and sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -727,6 +743,35 @@ files = [
 [package.extras]
 docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
+name = "data-platform"
+version = "0.1.0"
+description = "Data platform for DestaquesGovBr - PostgreSQL migration and data pipelines"
+optional = true
+python-versions = "^3.11"
+groups = ["main"]
+markers = "extra == \"postgres\""
+files = []
+develop = true
+
+[package.dependencies]
+datasets = ">=2.16.0"
+huggingface-hub = ">=0.20.0"
+loguru = "^0.7.2"
+pandas = ">=2.1.4"
+psycopg2-binary = "^2.9.9"
+pyarrow = ">=14.0.1"
+pydantic = "^2.5.3"
+pydantic-settings = "^2.1.0"
+python-dotenv = "^1.0.0"
+sqlalchemy = "^2.0.23"
+tqdm = "^4.66.1"
+typer = "^0.9.0"
+
+[package.source]
+type = "directory"
+url = "../data-platform"
 
 [[package]]
 name = "dataclasses-json"
@@ -2124,6 +2169,26 @@ requests = ">=2,<3"
 requests-toolbelt = ">=1.0.0,<2.0.0"
 
 [[package]]
+name = "loguru"
+version = "0.7.3"
+description = "Python logging made (stupidly) simple"
+optional = true
+python-versions = "<4.0,>=3.5"
+groups = ["main"]
+markers = "extra == \"postgres\""
+files = [
+    {file = "loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c"},
+    {file = "loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6"},
+]
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==8.1.3)", "build (==1.2.2)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.5.0)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.13.0)", "mypy (==v1.4.1)", "myst-parser (==4.0.0)", "pre-commit (==4.0.1)", "pytest (==6.1.2)", "pytest (==8.3.2)", "pytest-cov (==2.12.1)", "pytest-cov (==5.0.0)", "pytest-cov (==6.0.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.1.0)", "sphinx-rtd-theme (==3.0.2)", "tox (==3.27.1)", "tox (==4.23.2)", "twine (==6.0.1)"]
+
+[[package]]
 name = "markdown"
 version = "3.7"
 description = "Python implementation of John Gruber's Markdown."
@@ -3197,6 +3262,84 @@ files = [
 [package.extras]
 dev = ["black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pytest-cov", "requests", "rstcheck", "ruff", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "wheel"]
 test = ["pytest", "pytest-xdist", "setuptools"]
+
+[[package]]
+name = "psycopg2-binary"
+version = "2.9.11"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+optional = true
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "extra == \"postgres\""
+files = [
+    {file = "psycopg2-binary-2.9.11.tar.gz", hash = "sha256:b6aed9e096bf63f9e75edf2581aa9a7e7186d97ab5c177aa6c87797cd591236c"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d6fe6b47d0b42ce1c9f1fa3e35bb365011ca22e39db37074458f27921dca40f2"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a6c0e4262e089516603a09474ee13eabf09cb65c332277e39af68f6233911087"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c47676e5b485393f069b4d7a811267d3168ce46f988fa602658b8bb901e9e64d"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:a28d8c01a7b27a1e3265b11250ba7557e5f72b5ee9e5f3a2fa8d2949c29bf5d2"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5f3f2732cf504a1aa9e9609d02f79bea1067d99edf844ab92c247bbca143303b"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:865f9945ed1b3950d968ec4690ce68c55019d79e4497366d36e090327ce7db14"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:91537a8df2bde69b1c1db01d6d944c831ca793952e4f57892600e96cee95f2cd"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4dca1f356a67ecb68c81a7bc7809f1569ad9e152ce7fd02c2f2036862ca9f66b"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0da4de5c1ac69d94ed4364b6cbe7190c1a70d325f112ba783d83f8440285f152"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37d8412565a7267f7d79e29ab66876e55cb5e8e7b3bbf94f8206f6795f8f7e7e"},
+    {file = "psycopg2_binary-2.9.11-cp310-cp310-win_amd64.whl", hash = "sha256:c665f01ec8ab273a61c62beeb8cce3014c214429ced8a308ca1fc410ecac3a39"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0e8480afd62362d0a6a27dd09e4ca2def6fa50ed3a4e7c09165266106b2ffa10"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:763c93ef1df3da6d1a90f86ea7f3f806dc06b21c198fa87c3c25504abec9404a"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2e164359396576a3cc701ba8af4751ae68a07235d7a380c631184a611220d9a4"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:d57c9c387660b8893093459738b6abddbb30a7eab058b77b0d0d1c7d521ddfd7"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2c226ef95eb2250974bf6fa7a842082b31f68385c4f3268370e3f3870e7859ee"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a311f1edc9967723d3511ea7d2708e2c3592e3405677bf53d5c7246753591fbb"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ebb415404821b6d1c47353ebe9c8645967a5235e6d88f914147e7fd411419e6f"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f07c9c4a5093258a03b28fab9b4f151aa376989e7f35f855088234e656ee6a94"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:00ce1830d971f43b667abe4a56e42c1e2d594b32da4802e44a73bacacb25535f"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:cffe9d7697ae7456649617e8bb8d7a45afb71cd13f7ab22af3e5c61f04840908"},
+    {file = "psycopg2_binary-2.9.11-cp311-cp311-win_amd64.whl", hash = "sha256:304fd7b7f97eef30e91b8f7e720b3db75fee010b520e434ea35ed1ff22501d03"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:be9b840ac0525a283a96b556616f5b4820e0526addb8dcf6525a0fa162730be4"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f090b7ddd13ca842ebfe301cd587a76a4cf0913b1e429eb92c1be5dbeb1a19bc"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ab8905b5dcb05bf3fb22e0cf90e10f469563486ffb6a96569e51f897c750a76a"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf940cd7e7fec19181fdbc29d76911741153d51cab52e5c21165f3262125685e"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa0f693d3c68ae925966f0b14b8edda71696608039f4ed61b1fe9ffa468d16db"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a1cf393f1cdaf6a9b57c0a719a1068ba1069f022a59b8b1fe44b006745b59757"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7a6beb4beaa62f88592ccc65df20328029d721db309cb3250b0aae0fa146c3"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:31b32c457a6025e74d233957cc9736742ac5a6cb196c6b68499f6bb51390bd6a"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:edcb3aeb11cb4bf13a2af3c53a15b3d612edeb6409047ea0b5d6a21a9d744b34"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b6d93d7c0b61a1dd6197d208ab613eb7dcfdcca0a49c42ceb082257991de9d"},
+    {file = "psycopg2_binary-2.9.11-cp312-cp312-win_amd64.whl", hash = "sha256:b33fabeb1fde21180479b2d4667e994de7bbf0eec22832ba5d9b5e4cf65b6c6d"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b8fb3db325435d34235b044b199e56cdf9ff41223a4b9752e8576465170bb38c"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:366df99e710a2acd90efed3764bb1e28df6c675d33a7fb40df9b7281694432ee"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c55b385daa2f92cb64b12ec4536c66954ac53654c7f15a203578da4e78105c0"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c0377174bf1dd416993d16edc15357f6eb17ac998244cca19bc67cdc0e2e5766"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5c6ff3335ce08c75afaed19e08699e8aacf95d4a260b495a4a8545244fe2ceb3"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84011ba3109e06ac412f95399b704d3d6950e386b7994475b231cf61eec2fc1f"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ba34475ceb08cccbdd98f6b46916917ae6eeb92b5ae111df10b544c3a4621dc4"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b31e90fdd0f968c2de3b26ab014314fe814225b6c324f770952f7d38abf17e3c"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d526864e0f67f74937a8fce859bd56c979f5e2ec57ca7c627f5f1071ef7fee60"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:04195548662fa544626c8ea0f06561eb6203f1984ba5b4562764fbeb4c3d14b1"},
+    {file = "psycopg2_binary-2.9.11-cp313-cp313-win_amd64.whl", hash = "sha256:efff12b432179443f54e230fdf60de1f6cc726b6c832db8701227d089310e8aa"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:92e3b669236327083a2e33ccfa0d320dd01b9803b3e14dd986a4fc54aa00f4e1"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e0deeb03da539fa3577fcb0b3f2554a97f7e5477c246098dbb18091a4a01c16f"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b52a3f9bb540a3e4ec0f6ba6d31339727b2950c9772850d6545b7eae0b9d7c5"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:db4fd476874ccfdbb630a54426964959e58da4c61c9feba73e6094d51303d7d8"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:47f212c1d3be608a12937cc131bd85502954398aaa1320cb4c14421a0ffccf4c"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e35b7abae2b0adab776add56111df1735ccc71406e56203515e228a8dc07089f"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fcf21be3ce5f5659daefd2b3b3b6e4727b028221ddc94e6c1523425579664747"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9bd81e64e8de111237737b29d68039b9c813bdf520156af36d26819c9a979e5f"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:32770a4d666fbdafab017086655bcddab791d7cb260a16679cc5a7338b64343b"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3cb3a676873d7506825221045bd70e0427c905b9c8ee8d6acd70cfcbd6e576d"},
+    {file = "psycopg2_binary-2.9.11-cp314-cp314-win_amd64.whl", hash = "sha256:4012c9c954dfaccd28f94e84ab9f94e12df76b4afb22331b1f0d3154893a6316"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:20e7fb94e20b03dcc783f76c0865f9da39559dcc0c28dd1a3fce0d01902a6b9c"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4bdab48575b6f870f465b397c38f1b415520e9879fdf10a53ee4f49dcbdf8a21"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9d3a9edcfbe77a3ed4bc72836d466dfce4174beb79eda79ea155cc77237ed9e8"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:44fc5c2b8fa871ce7f0023f619f1349a0aa03a0857f2c96fbc01c657dcbbdb49"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9c55460033867b4622cda1b6872edf445809535144152e5d14941ef591980edf"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2d11098a83cca92deaeaed3d58cfd150d49b3b06ee0d0852be466bf87596899e"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:691c807d94aecfbc76a14e1408847d59ff5b5906a04a23e12a89007672b9e819"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:8b81627b691f29c4c30a8f322546ad039c40c328373b11dff7490a3e1b517855"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:b637d6d941209e8d96a072d7977238eea128046effbf37d1d8b2c0764750017d"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:41360b01c140c2a03d346cec3280cf8a71aa07d94f3b1509fa0161c366af66b4"},
+    {file = "psycopg2_binary-2.9.11-cp39-cp39-win_amd64.whl", hash = "sha256:875039274f8a2361e5207857899706da840768e2a775bf8c65e82f60b197df02"},
+]
 
 [[package]]
 name = "ptyprocess"
@@ -4553,6 +4696,29 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,<8.2)", "pytest-mock", "pytest-mypy-testing"]
 
 [[package]]
+name = "typer"
+version = "0.9.4"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = true
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "extra == \"postgres\""
+files = [
+    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
+    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
+]
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
+doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
+test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
+
+[[package]]
 name = "types-python-dateutil"
 version = "2.9.0.20241003"
 description = "Typing stubs for python-dateutil"
@@ -4689,6 +4855,22 @@ files = [
 docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx-rtd-theme (>=1.1.0)"]
 optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+description = "A small Python utility to set file creation time on Windows"
+optional = true
+python-versions = ">=3.5"
+groups = ["main"]
+markers = "extra == \"postgres\" and sys_platform == \"win32\""
+files = [
+    {file = "win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390"},
+    {file = "win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0"},
+]
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 
 [[package]]
 name = "xxhash"
@@ -4920,7 +5102,10 @@ idna = ">=2.0"
 multidict = ">=4.0"
 propcache = ">=0.2.0"
 
+[extras]
+postgres = ["data-platform"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "5bbd22891122abbdb9c45ae92727fbf20654d61998338d8ba27e77486dde0fbd"
+content-hash = "fd9c1e5be09599499c92673f2b53d5570286128ad589d746ce28de78b7ad6d7c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ retry = "^0.9.2"
 markdownify = "^0.14.1"
 algoliasearch = "^4.13.0"
 scipy = "^1.16.2"
+# Data platform for PostgreSQL storage (optional - only needed for dual_write mode)
+data-platform = { path = "../data-platform", develop = true, optional = true }
+
+[tool.poetry.extras]
+postgres = ["data-platform"]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.3.3"

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 
 from enrichment.augmentation_manager import AugmentationManager
-from dataset_manager import DatasetManager
+from storage_wrapper import StorageWrapper
 from dotenv import load_dotenv
 from scraper.scrape_manager import ScrapeManager
 from scraper.ebc_scrape_manager import EBCScrapeManager
@@ -20,8 +20,8 @@ def run_scraper(args):
     """
     Executes the scraper logic using the arguments provided by the 'scrape' subcommand.
     """
-    dataset_manager = DatasetManager()
-    scrape_manager = ScrapeManager(dataset_manager)
+    storage = StorageWrapper()
+    scrape_manager = ScrapeManager(storage)
 
     # Convert agency input into a list (comma-separated values)
     agencies = args.agencies.split(",") if args.agencies else None
@@ -35,8 +35,8 @@ def run_ebc_scraper(args):
     """
     Executes the EBC scraper logic using the arguments provided by the 'scrape-ebc' subcommand.
     """
-    dataset_manager = DatasetManager()
-    ebc_scrape_manager = EBCScrapeManager(dataset_manager)
+    storage = StorageWrapper()
+    ebc_scrape_manager = EBCScrapeManager(storage)
 
     ebc_scrape_manager.run_scraper(
         args.start_date, args.end_date, args.sequential, args.allow_update

--- a/src/scraper/ebc_scrape_manager.py
+++ b/src/scraper/ebc_scrape_manager.py
@@ -2,9 +2,8 @@ import hashlib
 import logging
 from collections import OrderedDict
 from datetime import date, datetime
-from typing import Dict, List
+from typing import Any, Dict, List
 
-from dataset_manager import DatasetManager
 from scraper.ebc_webscraper import EBCWebScraper
 
 # Set up logging configuration
@@ -28,8 +27,14 @@ class EBCScrapeManager:
         a dataset manager.
     """
 
-    def __init__(self, dataset_manager: DatasetManager):
-        self.dataset_manager = dataset_manager
+    def __init__(self, storage: Any):
+        """
+        Initialize EBCScrapeManager with a storage backend.
+
+        Args:
+            storage: Storage backend (StorageWrapper or DatasetManager)
+        """
+        self.dataset_manager = storage  # Keep attribute name for compatibility
 
     def run_scraper(
         self,

--- a/src/scraper/scrape_manager.py
+++ b/src/scraper/scrape_manager.py
@@ -3,10 +3,9 @@ import logging
 import os
 from collections import OrderedDict
 from datetime import date
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import yaml
-from dataset_manager import DatasetManager
 from scraper.webscraper import WebScraper
 
 # Set up logging configuration
@@ -31,8 +30,14 @@ class ScrapeManager:
         a dataset manager.
     """
 
-    def __init__(self, dataset_manager: DatasetManager):
-        self.dataset_manager = dataset_manager
+    def __init__(self, storage: Any):
+        """
+        Initialize ScrapeManager with a storage backend.
+
+        Args:
+            storage: Storage backend (StorageWrapper or DatasetManager)
+        """
+        self.dataset_manager = storage  # Keep attribute name for compatibility
 
     def _load_urls_from_yaml(self, file_name: str, agency: str = None) -> List[str]:
         """

--- a/src/storage_wrapper.py
+++ b/src/storage_wrapper.py
@@ -1,0 +1,166 @@
+"""
+Storage wrapper that uses StorageAdapter when available,
+falls back to DatasetManager for legacy operations.
+
+This wrapper enables dual-write mode where data is written to both
+PostgreSQL and HuggingFace simultaneously.
+
+Environment variables:
+- STORAGE_BACKEND: 'huggingface' (default), 'postgres', or 'dual_write'
+- STORAGE_READ_FROM: 'huggingface' (default) or 'postgres'
+- DATABASE_URL: PostgreSQL connection string (required for postgres/dual_write)
+- HF_TOKEN: HuggingFace token (required for huggingface/dual_write)
+"""
+
+import logging
+import os
+from typing import Optional, OrderedDict
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+class StorageWrapper:
+    """
+    Unified storage interface that abstracts backend selection.
+
+    Supports three modes:
+    - huggingface: Write to HuggingFace only (legacy behavior)
+    - postgres: Write to PostgreSQL only
+    - dual_write: Write to both backends (migration phase)
+    """
+
+    def __init__(self):
+        self.backend = os.getenv("STORAGE_BACKEND", "huggingface").lower()
+        self._storage = None
+        self._use_adapter = False
+
+        logger.info(f"StorageWrapper initializing with backend: {self.backend}")
+
+        if self.backend in ("postgres", "dual_write"):
+            self._init_storage_adapter()
+        else:
+            self._init_dataset_manager()
+
+    def _init_storage_adapter(self):
+        """Initialize StorageAdapter from data-platform."""
+        try:
+            from data_platform.managers import StorageAdapter
+
+            logger.info("Using StorageAdapter for storage operations")
+            self._storage = StorageAdapter()
+            self._use_adapter = True
+        except ImportError as e:
+            logger.error(
+                f"Failed to import StorageAdapter: {e}. "
+                "Make sure data-platform is installed: pip install -e ../data-platform"
+            )
+            raise ImportError(
+                "StorageAdapter not found. Install data-platform or set STORAGE_BACKEND=huggingface"
+            ) from e
+
+    def _init_dataset_manager(self):
+        """Initialize legacy DatasetManager."""
+        from dataset_manager import DatasetManager
+
+        logger.info("Using DatasetManager (HuggingFace) for storage operations")
+        self._storage = DatasetManager()
+        self._use_adapter = False
+
+    def insert(self, new_data: OrderedDict, allow_update: bool = False) -> int:
+        """
+        Insert new records into storage.
+
+        Args:
+            new_data: OrderedDict with arrays for each column
+            allow_update: If True, update existing records with same unique_id
+
+        Returns:
+            Number of records inserted/updated
+        """
+        total = len(new_data.get("unique_id", []))
+        logger.info(f"Inserting {total} records (backend={self.backend})")
+
+        result = self._storage.insert(new_data, allow_update=allow_update)
+
+        # DatasetManager doesn't return count, so return total
+        if not self._use_adapter:
+            return total
+        return result
+
+    def update(self, updated_df: pd.DataFrame) -> int:
+        """
+        Update existing records in storage.
+
+        Args:
+            updated_df: DataFrame with updates (must include unique_id column)
+
+        Returns:
+            Number of records updated
+        """
+        total = len(updated_df)
+        logger.info(f"Updating {total} records (backend={self.backend})")
+
+        result = self._storage.update(updated_df)
+
+        # DatasetManager doesn't return count, so return total
+        if not self._use_adapter:
+            return total
+        return result
+
+    def get(
+        self, min_date: str, max_date: str, agency: Optional[str] = None
+    ) -> pd.DataFrame:
+        """
+        Get records from storage by date range.
+
+        Args:
+            min_date: Minimum date (YYYY-MM-DD)
+            max_date: Maximum date (YYYY-MM-DD)
+            agency: Optional agency filter
+
+        Returns:
+            DataFrame with matching records
+        """
+        logger.info(f"Getting records: {min_date} to {max_date} (backend={self.backend})")
+        return self._storage.get(min_date, max_date, agency=agency)
+
+    # -------------------------------------------------------------------------
+    # Legacy methods for enrichment (only work with DatasetManager)
+    # -------------------------------------------------------------------------
+
+    def _load_existing_dataset(self):
+        """
+        Load existing dataset from HuggingFace.
+
+        Note: This method only works with DatasetManager backend.
+        For StorageAdapter, use get() instead.
+        """
+        if self._use_adapter:
+            raise NotImplementedError(
+                "_load_existing_dataset() is not available with StorageAdapter. "
+                "Use get(min_date, max_date) instead."
+            )
+        return self._storage._load_existing_dataset()
+
+    def _push_dataset_and_csvs(self, dataset):
+        """
+        Push dataset and CSVs to HuggingFace.
+
+        Note: This method only works with DatasetManager backend.
+        StorageAdapter handles push automatically on insert/update.
+        """
+        if self._use_adapter:
+            raise NotImplementedError(
+                "_push_dataset_and_csvs() is not available with StorageAdapter. "
+                "Data is pushed automatically on insert/update."
+            )
+        return self._storage._push_dataset_and_csvs(dataset)
+
+    @property
+    def dataset_path(self) -> str:
+        """Get the HuggingFace dataset path (for legacy compatibility)."""
+        if self._use_adapter:
+            return "nitaibezerra/govbrnews"  # Default path
+        return self._storage.dataset_path


### PR DESCRIPTION
## Summary

- Adds `StorageWrapper` that enables writing to both HuggingFace and PostgreSQL simultaneously (dual-write mode) for the HF→PostgreSQL migration
- Backward compatible: defaults to HuggingFace-only mode when `STORAGE_BACKEND` is not set
- Tested locally with Docker PostgreSQL: 13 news records successfully written to both backends

## Changes

- **New file**: `src/storage_wrapper.py` - Wrapper with backend selection logic
- **Modified**: `src/main.py` - Uses StorageWrapper instead of DatasetManager
- **Modified**: `src/scraper/scrape_manager.py` - Accepts generic storage backend
- **Modified**: `src/scraper/ebc_scrape_manager.py` - Accepts generic storage backend
- **Modified**: `pyproject.toml` - Adds data-platform as optional dependency

## Environment Variables

| Variable | Values | Description |
|----------|--------|-------------|
| `STORAGE_BACKEND` | `huggingface` (default), `postgres`, `dual_write` | Backend for writes |
| `STORAGE_READ_FROM` | `huggingface`, `postgres` | Backend for reads |
| `DATABASE_URL` | PostgreSQL connection string | Required for postgres/dual_write |

## Usage

```bash
# Install with postgres support
poetry install --extras postgres

# Run with dual-write
STORAGE_BACKEND=dual_write \
STORAGE_READ_FROM=huggingface \
DATABASE_URL="postgresql://..." \
python src/main.py scrape --start-date 2025-12-20 --end-date 2025-12-20 --agencies gestao
```

## Test plan

- [x] Tested locally with Docker PostgreSQL
- [x] Verified 13 records inserted in both HuggingFace and PostgreSQL
- [ ] Configure GitHub Actions with `STORAGE_BACKEND=dual_write`
- [ ] Monitor dual-write for 5 days in production

## Related

- Part of the HF → PostgreSQL migration (Phase 4: Dual-Write)
- Depends on: data-platform StorageAdapter (PR #5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)